### PR TITLE
fix(workday-calculator): use holiday_date and fix separator truncation

### DIFF
--- a/mcp-tools/workday-calculator/workday_calculator/output/exporter.py
+++ b/mcp-tools/workday-calculator/workday_calculator/output/exporter.py
@@ -157,7 +157,7 @@ class ResultExporter:
             # Write data
             for holiday in holidays:
                 writer.writerow([
-                    holiday.date.isoformat(),
+                    holiday.holiday_date.isoformat(),
                     holiday.name,
                     holiday.is_national,
                 ])
@@ -208,7 +208,7 @@ class ResultExporter:
             },
             "holidays": [
                 {
-                    "date": h.date.isoformat(),
+                    "date": h.holiday_date.isoformat(),
                     "name": h.name,
                     "is_national": h.is_national,
                 }

--- a/mcp-tools/workday-calculator/workday_calculator/output/formatter.py
+++ b/mcp-tools/workday-calculator/workday_calculator/output/formatter.py
@@ -67,7 +67,7 @@ class ConsoleFormatter:
             f"- {result.weekend_days} ({result.weekends_detail.get('saturdays', 0)} Sat, {result.weekends_detail.get('sundays', 0)} Sun)",
         )
         calc_table.add_row("Holidays (on workdays):", f"- {result.holidays_count}")
-        calc_table.add_row("", "─" * 15)
+        calc_table.add_row("", "─────────")
         calc_table.add_row(
             Text("Working Days:", style="bold green"),
             Text(str(result.working_days), style="bold green"),
@@ -102,9 +102,9 @@ class ConsoleFormatter:
         weekday_names = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
         for holiday in holidays:
-            weekday = weekday_names[holiday.date.weekday()]
+            weekday = weekday_names[holiday.holiday_date.weekday()]
             holiday_table.add_row(
-                holiday.date.strftime("%d.%m.%Y"),
+                holiday.holiday_date.strftime("%d.%m.%Y"),
                 weekday,
                 holiday.name,
             )


### PR DESCRIPTION
I had the following error, which i fixed with cursor (sonnet 4.6) pls consider for merging

workday-calc calculate -s 2026-03-01 -e 2026-08-31 -b BY

───────────────────────────────────────────────────────────────────────────────────────────────── Workday Calculation Result ──────────────────────────────────────────────────────────────────────────────────────────────────
=== Some Code ommitted=== 
╭───────────────────────────────────────────────────────────────────────────────────────────────────── Location & Period ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
│  Period:               01.03.2026 - 31.08.2026                                                                                                                                                                              │
│  Location:             Bayern (BY)                                                                                                                                                                                          │
│  Resolution Method:    Manual                                                                                                                                                                                               │
│  Confidence:           100%                                                                                                                                                                                                 │
╰────────────────────────────────────────────────────────
Error: Unexpected error: 'Holiday' object has no attribute 'date'

Fixed it with Cursor:

- Use Holiday.holiday_date instead of .date in formatter and exporter (fixes 'Holiday' object has no attribute 'date')
- Shorten calculation table separator to avoid Rich overflow ellipsis

Made-with: Cursor